### PR TITLE
Make top navagation element sticky

### DIFF
--- a/Style sheets/recherche.css
+++ b/Style sheets/recherche.css
@@ -1,6 +1,8 @@
 
 .barrerech {
+     top: 10px;
      margin-top: 10px;
+     position: sticky;
 }
 .signaturebarrerech{
      width: 100px;
@@ -17,7 +19,6 @@
      text-decoration: none;
      color: black;
      position: absolute;
-     top: 10px;
      margin: 10px;
      margin-left: -10px;
      background-color: #fafafa;
@@ -36,7 +37,6 @@
      text-decoration: none;
      color: black;
      position: absolute;
-     top: 10px;
      margin: 10px;
      margin-left: 64px;
      background-color: #fafafa;
@@ -55,7 +55,6 @@
      text-decoration: none;
      color: black;
      position: absolute;
-     top: 10px;
      margin: 10px;
      margin-left: 200px;
      background-color: #fafafa;

--- a/Style sheets/style.css
+++ b/Style sheets/style.css
@@ -344,7 +344,6 @@ hr {
   padding-bottom: 20px;
 }
 html, body {
-  overflow-x: hidden;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Fixes #2:

* Remove `overflow-x` attribute from `html` and `body` element CSS style because it prevents `position: sticky`.

* Add to margin to the navbar to maintain the initial margin when the page is scrolled.

* Remove top margins from navigation links, they are not needed now.